### PR TITLE
Add CALLBACK_WINDOW_TYPES choices

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -44,6 +44,12 @@ REQUIRES_ACTION_BY = Choices(
     ('PROVIDER', '2_provider', 'Provider'),
 )
 
+CALLBACK_WINDOW_TYPES = Choices(
+    # constant, db_id, friendly string
+    ('HALF_HOUR_EITHER_SIDE', 'HALF_HOUR_EITHER_SIDE', 'Single time, with phone call up to 30 minutes before or after'),
+    ('HALF_HOUR_WINDOW', 'HALF_HOUR_WINDOW', 'Half hour time slot'),
+)
+
 MATTER_TYPE_LEVELS = Choices(
     # constant, db_id, friendly string
     ('ONE', 1, '1'),


### PR DESCRIPTION
## What does this pull request do?

Adds a `Choices` object to the constants file, with `CALLBACK_WINDOW_TYPES` to represent alternative modes of behaviour in arranging callbacks (whether it's a single time with the call up to half an hour either side of it, or an explicit half hour time slot)

## Any other changes that would benefit highlighting?

Intentionally left blank.
