### PR TITLE
LGA-876 - Remove 'Not safe to leave a message' contact safety option

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -264,7 +264,6 @@ CONTACT_SAFETY = Choices(
     # constant, db_id, friendly string
     ('SAFE', 'SAFE', 'Safe to contact'),
     ('DONT_CALL', 'DONT_CALL', 'Not safe to call'),
-    ('NO_MESSAGE', 'NO_MESSAGE', 'Not safe to leave a message'),
 )
 
 EMAIL_SAFETY = Choices(


### PR DESCRIPTION
## What does this pull request do?

Remove 'Not safe to leave a message' contact safety option

## Any other changes that would benefit highlighting?

Intentionally left blank.
