### PR TITLE
Adding shared OPERATOR_HOURS constant to be used by cla_backend and cla_public

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -511,3 +511,12 @@ REASONS_FOR_CONTACTING = Choices(
     ('PNS', 'PNS', u'I’d prefer not to say'),
     ('OTHER', 'OTHER', u'Another reason'),
 )
+
+OPERATOR_HOURS = {
+    "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
+    "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
+    "2018-12-24": (datetime.time(9, 0), datetime.time(17, 30)),
+    "2018-12-31": (datetime.time(9, 0), datetime.time(17, 30)),
+    "2019-12-24": (datetime.time(9, 0), datetime.time(18, 00)),
+    "2019-12-31": (datetime.time(9, 0), datetime.time(18, 00)),
+}


### PR DESCRIPTION
## What does this pull request do?

Adding shared OPERATOR_HOURS constant to be used by cla_backend and cla_public

## Any other changes that would benefit highlighting?

Intentionally left blank.
