### PR TITLE
Revert "LGA-876 - Remove 'Not safe to leave a message' contact safety option"

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -264,6 +264,7 @@ CONTACT_SAFETY = Choices(
     # constant, db_id, friendly string
     ('SAFE', 'SAFE', 'Safe to contact'),
     ('DONT_CALL', 'DONT_CALL', 'Not safe to call'),
+    ('NO_MESSAGE', 'NO_MESSAGE', 'Not safe to leave a message'),
 )
 
 EMAIL_SAFETY = Choices(


### PR DESCRIPTION
Reverts ministryofjustice/cla_common#86

https://github.com/ministryofjustice/cla_backend/pull/602 which uses this change is not ready yet. It was a mistake to merge this anyway as it should only go into develop once it's ready to deploy