### PR TITLE
Fix missing import datetime on cla_common constants

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from os import environ as env
+import datetime
 
 from extended_choices import Choices
 


### PR DESCRIPTION
## What does this pull request do?

Fix missing import datetime on cla_common constants

## Any other changes that would benefit highlighting?

Intentionally left blank.
