### PR TITLE
LGA-973 - Remove hard dependency on django.core.cache.cache and django.utils.translation.ugettext_lazy

### DIFF
--- a/cla_common/call_centre_availability/__init__.py
+++ b/cla_common/call_centre_availability/__init__.py
@@ -45,7 +45,7 @@ class BankHolidays(object):
         self.init_cache()
 
     def init_cache(self):
-        self._cache = CacheAdapter.get_cache_adapter()
+        self._cache = CacheAdapter.get_adapter()
 
     @property
     def url(self):

--- a/cla_common/call_centre_availability/__init__.py
+++ b/cla_common/call_centre_availability/__init__.py
@@ -19,7 +19,7 @@ def in_the_past(time):
 
 
 def before_9am(time):
-    return time.time() < datetime.time(9, 0)
+	return time.time() < datetime.time(9, 0)
 
 
 def after_8pm(time):

--- a/cla_common/call_centre_availability/__init__.py
+++ b/cla_common/call_centre_availability/__init__.py
@@ -2,25 +2,11 @@ import datetime
 from itertools import ifilter, imap, islice, takewhile
 import requests
 
+from cla_common.services import CacheAdapter
 
 BANK_HOLIDAYS_URL = 'https://www.gov.uk/bank-holidays/england-and-wales.json'
 
 SLOT_INTERVAL_MINS = 30
-
-
-class CacheAdapter:
-    _cache_adapter_factory = None
-    @classmethod
-    def set_cache_adapter_factory(cls, cache_adpater_factory):
-        cls._cache_adapter_factory = staticmethod(cache_adpater_factory)
-
-    @classmethod
-    def get_cache_adapter(cls):
-        if cls._cache_adapter_factory:
-            factory = cls._cache_adapter_factory
-            return factory()
-        return None
-
 
 
 def current_datetime():

--- a/cla_common/call_centre_availability/__init__.py
+++ b/cla_common/call_centre_availability/__init__.py
@@ -19,7 +19,7 @@ def in_the_past(time):
 
 
 def before_9am(time):
-	return time.time() < datetime.time(9, 0)
+    return time.time() < datetime.time(9, 0)
 
 
 def after_8pm(time):

--- a/cla_common/call_centre_availability/__init__.py
+++ b/cla_common/call_centre_availability/__init__.py
@@ -8,6 +8,21 @@ BANK_HOLIDAYS_URL = 'https://www.gov.uk/bank-holidays/england-and-wales.json'
 SLOT_INTERVAL_MINS = 30
 
 
+class CacheAdapter:
+    _cache_adapter_factory = None
+    @classmethod
+    def set_cache_adapter_factory(cls, cache_adpater_factory):
+        cls._cache_adapter_factory = staticmethod(cache_adpater_factory)
+
+    @classmethod
+    def get_cache_adapter(cls):
+        if cls._cache_adapter_factory:
+            factory = cls._cache_adapter_factory
+            return factory()
+        return None
+
+
+
 def current_datetime():
     # this function is to make unit testing simpler
     return datetime.datetime.now()
@@ -44,8 +59,7 @@ class BankHolidays(object):
         self.init_cache()
 
     def init_cache(self):
-        from django.core.cache import cache
-        self._cache = cache
+        self._cache = CacheAdapter.get_cache_adapter()
 
     @property
     def url(self):

--- a/cla_common/money_interval/models.py
+++ b/cla_common/money_interval/models.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from decimal import Decimal
+from cla_common.services import translate
 
 
 TWO_DP = Decimal('.01')
@@ -10,16 +11,12 @@ class MoneyInterval(object):
     value = None  # in pennies
     interval_period = None
     per_interval_value = None  # in pennies
-
-    # Translation handler
-    translator = lambda string: string
-
     # interval_name, user_copy_name, multiply_factor (to get monthly value)
-    _intervals = [('per_week', translator('per week'), 52.0 / 12.0),
-                  ('per_2week', translator('2 weekly'), 26.0 / 12.0),
-                  ('per_4week', translator('4 weekly'), 13.0 / 12.0),
-                  ('per_month', translator('per month'), 1.0),
-                  ('per_year', translator('per year'), 1.0 / 12.0)
+    _intervals = [('per_week', translate('per week'), 52.0 / 12.0),
+                  ('per_2week', translate('2 weekly'), 26.0 / 12.0),
+                  ('per_4week', translate('4 weekly'), 13.0 / 12.0),
+                  ('per_month', translate('per month'), 1.0),
+                  ('per_year', translate('per year'), 1.0 / 12.0)
     ]
 
     _intervals_dict = {i[0]: {'user_copy_name': i[1], 'multiply_factor': i[2]}

--- a/cla_common/money_interval/models.py
+++ b/cla_common/money_interval/models.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from decimal import Decimal
 
-from django.utils.translation import ugettext_lazy as _
 
 TWO_DP = Decimal('.01')
 ZERO_DP = Decimal('1')
@@ -12,12 +11,15 @@ class MoneyInterval(object):
     interval_period = None
     per_interval_value = None  # in pennies
 
+    # Translation handler
+    translator = lambda string: string
+
     # interval_name, user_copy_name, multiply_factor (to get monthly value)
-    _intervals = [('per_week', _('per week'), 52.0 / 12.0),
-                  ('per_2week', _('2 weekly'), 26.0 / 12.0),
-                  ('per_4week', _('4 weekly'), 13.0 / 12.0),
-                  ('per_month', _('per month'), 1.0),
-                  ('per_year', _('per year'), 1.0 / 12.0)
+    _intervals = [('per_week', translator('per week'), 52.0 / 12.0),
+                  ('per_2week', translator('2 weekly'), 26.0 / 12.0),
+                  ('per_4week', translator('4 weekly'), 13.0 / 12.0),
+                  ('per_month', translator('per month'), 1.0),
+                  ('per_year', translator('per year'), 1.0 / 12.0)
     ]
 
     _intervals_dict = {i[0]: {'user_copy_name': i[1], 'multiply_factor': i[2]}

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -1,35 +1,35 @@
-class TranslationAdapter(object):
-    _translation_adapter_factory = None
+class BaseAdapter(object):
+    _instance = None
+    _adapter_factory = None
+    @classmethod
+    def set_adapter_factory(cls, adapter_factory):
+        # The staticmethod for the factory is needed because this will be an unbound callable, Not needed got Python3
+        cls._adapter_factory = staticmethod(adapter_factory)
+        cls._instance = None
 
     @classmethod
-    def set_translation_adapter_factory(cls, translation_adapter_factory):
-        cls._translation_adapter_factory = translation_adapter_factory
+    def get_adapter(cls):
+        if not cls._instance and cls._adapter_factory:
+            cls._instance = cls.get_instance_from_factory(cls._adapter_factory)
+        return cls._instance
 
-    @classmethod
-    def get_translation_adapter(cls):
-        if cls._translation_adapter_factory:
-            factory = cls._translation_adapter_factory
-            return factory()
-        return None
+    @staticmethod
+    def get_instance_from_factory(factory):
+        return factory()
 
 
-class CacheAdapter(object):
-    _cache_adapter_factory = None
+class TranslationAdapter(BaseAdapter):
+    @staticmethod
+    def get_instance_from_factory(factory):
+        return staticmethod(factory())
 
-    @classmethod
-    def set_cache_adapter_factory(cls, cache_adapter_factory):
-        cls._cache_adapter_factory = staticmethod(cache_adapter_factory)
 
-    @classmethod
-    def get_cache_adapter(cls):
-        if cls._cache_adapter_factory:
-            factory = cls._cache_adapter_factory
-            return factory()
-        return None
+class CacheAdapter(BaseAdapter):
+    pass
 
 
 def translate(string):
-    translator = TranslationAdapter.get_translation_adapter()
+    translator = TranslationAdapter.get_adapter()
     if translator:
         return translator(string)
     return string

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -1,34 +1,35 @@
-
 class TranslationAdapter(object):
-	_translation_adapter_factory = None
-	@classmethod
-	def set_translation_adapter_factory(cls, translation_adapter_factory):
-		cls._translation_adapter_factory = translation_adapter_factory
+    _translation_adapter_factory = None
 
-	@classmethod
-	def get_translation_adapter(cls):
-		if cls._translation_adapter_factory:
-			factory = cls._translation_adapter_factory
-			return factory()
-		return None
+    @classmethod
+    def set_translation_adapter_factory(cls, translation_adapter_factory):
+        cls._translation_adapter_factory = translation_adapter_factory
+
+    @classmethod
+    def get_translation_adapter(cls):
+        if cls._translation_adapter_factory:
+            factory = cls._translation_adapter_factory
+            return factory()
+        return None
 
 
-class CacheAdapter:
-	_cache_adapter_factory = None
-	@classmethod
-	def set_cache_adapter_factory(cls, cache_adapter_factory):
-		cls._cache_adapter_factory = staticmethod(cache_adapter_factory)
+class CacheAdapter(object):
+    _cache_adapter_factory = None
 
-	@classmethod
-	def get_cache_adapter(cls):
-		if cls._cache_adapter_factory:
-			factory = cls._cache_adapter_factory
-			return factory()
-		return None
+    @classmethod
+    def set_cache_adapter_factory(cls, cache_adapter_factory):
+        cls._cache_adapter_factory = staticmethod(cache_adapter_factory)
+
+    @classmethod
+    def get_cache_adapter(cls):
+        if cls._cache_adapter_factory:
+            factory = cls._cache_adapter_factory
+            return factory()
+        return None
 
 
 def translate(string):
-	translator = TranslationAdapter.get_translation_adapter()
-	if translator:
-		return translator(string)
-	return string
+    translator = TranslationAdapter.get_translation_adapter()
+    if translator:
+        return translator(string)
+    return string

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -1,0 +1,34 @@
+
+class TranslationAdapter(object):
+	_translation_adapter_factory = None
+	@classmethod
+	def set_translation_adapter_factory(cls, translation_adapter_factory):
+		cls._translation_adapter_factory = translation_adapter_factory
+
+	@classmethod
+	def get_translation_adapter(cls):
+		if cls._translation_adapter_factory:
+			factory = cls._translation_adapter_factory
+			return factory()
+		return None
+
+
+class CacheAdapter:
+	_cache_adapter_factory = None
+	@classmethod
+	def set_cache_adapter_factory(cls, cache_adpater_factory):
+		cls._cache_adapter_factory = staticmethod(cache_adpater_factory)
+
+	@classmethod
+	def get_cache_adapter(cls):
+		if cls._cache_adapter_factory:
+			factory = cls._cache_adapter_factory
+			return factory()
+		return None
+
+
+def translate(string):
+	translator = TranslationAdapter.get_translation_adapter()
+	if translator:
+		return translator(string)
+	return string

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -10,17 +10,17 @@ class BaseAdapter(object):
     @classmethod
     def get_adapter(cls):
         if not cls._instance and cls._adapter_factory:
-            cls._instance = cls.get_instance_from_factory(cls._adapter_factory)
+            cls._instance = cls._get_instance_from_factory(cls._adapter_factory)
         return cls._instance
 
     @staticmethod
-    def get_instance_from_factory(factory):
+    def _get_instance_from_factory(factory):
         return factory()
 
 
 class TranslationAdapter(BaseAdapter):
     @staticmethod
-    def get_instance_from_factory(factory):
+    def _get_instance_from_factory(factory):
         return staticmethod(factory())
 
 

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -16,8 +16,8 @@ class TranslationAdapter(object):
 class CacheAdapter:
 	_cache_adapter_factory = None
 	@classmethod
-	def set_cache_adapter_factory(cls, cache_adpater_factory):
-		cls._cache_adapter_factory = staticmethod(cache_adpater_factory)
+	def set_cache_adapter_factory(cls, cache_adapter_factory):
+		cls._cache_adapter_factory = staticmethod(cache_adapter_factory)
 
 	@classmethod
 	def get_cache_adapter(cls):

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -1,3 +1,4 @@
+from speaklater import make_lazy_string
 class BaseAdapter(object):
     _instance = None
     _adapter_factory = None
@@ -29,7 +30,9 @@ class CacheAdapter(BaseAdapter):
 
 
 def translate(string):
-    translator = TranslationAdapter.get_adapter()
-    if translator:
-        return translator(string)
-    return string
+    def translation_callback(string_in):
+        adapter = TranslationAdapter.get_adapter()
+        if adapter:
+            return adapter(string_in)
+        return string_in
+    return make_lazy_string(translation_callback, string)

--- a/cla_common/services/__init__.py
+++ b/cla_common/services/__init__.py
@@ -4,7 +4,7 @@ class BaseAdapter(object):
     _adapter_factory = None
     @classmethod
     def set_adapter_factory(cls, adapter_factory):
-        # The staticmethod for the factory is needed because this will be an unbound callable, Not needed got Python3
+        # The staticmethod for the factory is needed because this will be an unbound callable. Not needed for Python3
         cls._adapter_factory = staticmethod(adapter_factory)
         cls._instance = None
 

--- a/cla_common/tests/test_bank_holidays_base.py
+++ b/cla_common/tests/test_bank_holidays_base.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+import unittest
+
+from .. import call_centre_availability
+
+
+class MonkeyPatch(object):
+
+    def __init__(self, obj, attr, value):
+        self.obj = obj
+        self.attr = attr
+        self.applied = False
+
+        if hasattr(obj, attr):
+            self.original = getattr(obj, attr)
+            setattr(obj, attr, value)
+            self.applied = True
+
+    def undo(self):
+        if self.applied:
+            setattr(self.obj, self.attr, self.original)
+
+
+def mock_bank_holidays():
+    return [datetime(2014, 12, 25, 0, 0)]
+
+
+class TestBankHolidaysBaseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.bank_holiday_patch = MonkeyPatch(
+            call_centre_availability,
+            'bank_holidays',
+            mock_bank_holidays)
+
+    def tearDown(self):
+        self.bank_holiday_patch.undo()

--- a/cla_common/tests/test_call_centre_availability.py
+++ b/cla_common/tests/test_call_centre_availability.py
@@ -171,29 +171,3 @@ class CallCentreAvailabilityTestCase(unittest.TestCase):
 
             OH = OpeningHours(**PROVIDER_HOURS)
             self.assertTrue(fake_now in OH)
-
-    def test_setting_cache_adpater(self):
-
-        def cache_adapter_factory(**kwargs):
-            cache = {}
-            def cache_get(name):
-                return cache.get(name)
-            def cache_set(name, value, *args, **kwargs):
-                cache[name] = value
-
-            test_cache = mock.Mock()
-            test_cache.get = mock.Mock(side_effect=cache_get)
-            test_cache.set = mock.Mock(side_effect=cache_set)
-            return test_cache
-
-        CacheAdapter.set_cache_adapter_factory(cache_adapter_factory)
-        bank_holidays = BankHolidays()
-        bank_holidays._load_dates = mock.Mock()
-        bank_holidays._parse_dates = mock.Mock()
-        # Get bank holiday days
-        bank_holidays.dates
-        self.assertTrue(bank_holidays._load_dates.called)
-
-        # Get bank holiday days
-        bank_holidays.dates
-        self.assertEqual(bank_holidays._load_dates.call_count, 1)

--- a/cla_common/tests/test_call_centre_availability.py
+++ b/cla_common/tests/test_call_centre_availability.py
@@ -1,14 +1,11 @@
 from datetime import datetime, time
 import unittest
+import mock
 from contextlib import contextmanager
-
-from django.forms import ValidationError
-import django
 
 from .. import call_centre_availability
 from ..call_centre_availability import available, time_slots, Hours, \
-    OpeningHours
-
+    OpeningHours, CacheAdapter, BankHolidays
 
 class MonkeyPatch(object):
 
@@ -174,3 +171,29 @@ class CallCentreAvailabilityTestCase(unittest.TestCase):
 
             OH = OpeningHours(**PROVIDER_HOURS)
             self.assertTrue(fake_now in OH)
+
+    def test_setting_cache_adpater(self):
+
+        def cache_adapter_factory(**kwargs):
+            cache = {}
+            def cache_get(name):
+                return cache.get(name)
+            def cache_set(name, value, *args, **kwargs):
+                cache[name] = value
+
+            test_cache = mock.Mock()
+            test_cache.get = mock.Mock(side_effect=cache_get)
+            test_cache.set = mock.Mock(side_effect=cache_set)
+            return test_cache
+
+        CacheAdapter.set_cache_adapter_factory(cache_adapter_factory)
+        bank_holidays = BankHolidays()
+        bank_holidays._load_dates = mock.Mock()
+        bank_holidays._parse_dates = mock.Mock()
+        # Get bank holiday days
+        bank_holidays.dates
+        self.assertTrue(bank_holidays._load_dates.called)
+
+        # Get bank holiday days
+        bank_holidays.dates
+        self.assertEqual(bank_holidays._load_dates.call_count, 1)

--- a/cla_common/tests/test_call_centre_availability.py
+++ b/cla_common/tests/test_call_centre_availability.py
@@ -1,11 +1,9 @@
 from datetime import datetime, time
 import unittest
-import mock
 from contextlib import contextmanager
 
 from .. import call_centre_availability
-from ..call_centre_availability import available, time_slots, Hours, \
-    OpeningHours, CacheAdapter, BankHolidays
+from ..call_centre_availability import available, time_slots, Hours, OpeningHours
 
 class MonkeyPatch(object):
 

--- a/cla_common/tests/test_services.py
+++ b/cla_common/tests/test_services.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import mock
+
+from cla_common.tests.test_bank_holidays_base import TestBankHolidaysBaseTestCase
+from cla_common.services import CacheAdapter, TranslationAdapter
+from cla_common.call_centre_availability import BankHolidays
+
+
+class ServicesTestCase(TestBankHolidaysBaseTestCase):
+
+    def test_setting_cache_adpater(self):
+
+        def cache_adapter_factory(**kwargs):
+            cache = {}
+
+            def cache_get(name):
+                return cache.get(name)
+
+            def cache_set(name, value, *args, **kwargs):
+                cache[name] = value
+
+            test_cache = mock.Mock()
+            test_cache.get = mock.Mock(side_effect=cache_get)
+            test_cache.set = mock.Mock(side_effect=cache_set)
+            return test_cache
+
+        CacheAdapter.set_adapter_factory(cache_adapter_factory)
+        bank_holidays = BankHolidays()
+        bank_holidays._load_dates = mock.Mock()
+        bank_holidays._parse_dates = mock.Mock()
+        # Get bank holiday days
+        bank_holidays.dates
+        self.assertTrue(bank_holidays._load_dates.called)
+
+        # Get bank holiday days
+        bank_holidays.dates
+        self.assertEqual(bank_holidays._load_dates.call_count, 1)
+
+    def test_setting_translation_adpater(self):
+
+        def translation_adapter_factory():
+            return lambda string: "--{}--".format(string)
+
+        TranslationAdapter.set_adapter_factory(translation_adapter_factory)
+        adapter = TranslationAdapter.get_adapter()
+        self.assertEqual(adapter("foo"), "--foo--")

--- a/cla_common/tests/test_services.py
+++ b/cla_common/tests/test_services.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import mock
 
 from cla_common.tests.test_bank_holidays_base import TestBankHolidaysBaseTestCase
-from cla_common.services import CacheAdapter, TranslationAdapter
+from cla_common.services import CacheAdapter, TranslationAdapter, translate
 from cla_common.call_centre_availability import BankHolidays
 
 
@@ -44,3 +44,15 @@ class ServicesTestCase(TestBankHolidaysBaseTestCase):
         TranslationAdapter.set_adapter_factory(translation_adapter_factory)
         adapter = TranslationAdapter.get_adapter()
         self.assertEqual(adapter("foo"), "--foo--")
+
+    def test_lazy_translation(self):
+        TranslationAdapter.set_adapter_factory(None)
+        string = translate("foo")
+        # Untranslated
+        self.assertEqual(string, "foo")
+
+        def translation_adapter_factory():
+            return lambda string_in: "--{}--".format(string_in)
+
+        TranslationAdapter.set_adapter_factory(translation_adapter_factory)
+        self.assertEqual(string, "--foo--")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django==1.7.9
 wheel==0.22.0
+speaklater==1.3
 # Additional requirements go here
 
 -e .


### PR DESCRIPTION
## What does this pull request do?

Remove import of `django.core.cache.cache` so that `cla_common.call_centre_availability.BankHolidays `can be used in places where django is not available

Moved translation and caching adapters into of cla_common.services package

## Any other changes that would benefit highlighting?

This is required so that we can remove django dependency in cla_public that uses the cla_common.call_centre_availability module

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"