### PR TITLE
Feature/lga 2376 update disregards

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -532,6 +532,8 @@ OPERATOR_HOURS = {
     "weekday": (datetime.time(9, 0), datetime.time(20, 0)),
     "saturday": (datetime.time(9, 0), datetime.time(12, 30)),
     "2021-12-24": (datetime.time(9, 0), datetime.time(17, 00)),
+    "2020-12-24": (datetime.time(9, 0), datetime.time(17, 00)),
+    "2020-12-31": (datetime.time(9, 0), datetime.time(17, 00)),
     "2020-12-26": (None, None),
     "2021-12-31": (datetime.time(9, 0), datetime.time(17, 00)),
 }

--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -462,6 +462,8 @@ DISREGARDS = Choices(
     ("NATIONAL_EMERGENCIES", "national_emergencies", "National Emergencies Trust"),
     ("LONDON_EMERGENCIES", "london_emergencies", "London Emergencies Trust"),
     ("LOVE_MANCHESTER", "love_manchester", "We Love Manchester Emergency Fund"),
+    ("ENERGY_PRICES", "energy_prices", "Energy prices Act 2022"),
+    ("COST_LIVING", "cost_living", "Cost of living payment- Social Security (additional payments) Act 2022"),
 )
 
 

--- a/requirements-py3-lint.txt
+++ b/requirements-py3-lint.txt
@@ -1,3 +1,4 @@
 flake8==3.8.1
 black==18.9b0
 click==8.0.4
+importlib_metadata<5


### PR DESCRIPTION
## What does this pull request do?

When the disregards questions are updated on cla_frontend, they also need to be validated on cla_backend. The validation is done using constants from cla_common.

## Any other changes that would benefit highlighting?

- CircleCi would not run as there was an issue with flake8, hence having to pin one of the imports
- A little while ago cla_common was updated and dates for testing where changed, this doesn't work on cla_backend so the old dates have been added back in as we need it to work on cla_public and cla_backend.

https://github.com/ministryofjustice/cla_common/commit/b060d5d0d53e7c07c248931f3b020c17ae8b60e6
