### PR TITLE
Remove 28th July 23 callbacks

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -537,4 +537,5 @@ OPERATOR_HOURS = {
     "2020-12-26": (None, None),
     "2021-12-31": (datetime.time(9, 0), datetime.time(17, 00)),
     "2023-07-27": (None, None),
+    "2023-07-28": (None, None),
 }


### PR DESCRIPTION
## What does this pull request do?

Remove callbacks for 28th July 2023 on request of call centre

## Any other changes that would benefit highlighting?

Intentionally left blank.
