### PR TITLE
LGA-3544: Add financial eligibility constants

### DIFF
--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -556,3 +556,23 @@ OPERATOR_HOURS = {
     "2023-07-27": (None, None),
     "2023-07-28": (None, None),
 }
+
+# Represents a users financial eligibility status from check if you can get legal aid
+FINANCIAL_ASSESSMENT_STATUSES = Choices(
+    # constant, db_id, display string
+    ("PASSED", "PASSED", "Passed"),
+    ("FAILED", "FAILED", "Failed"),
+    ("FAST_TRACK", "FAST_TRACK", "Client told to call the helpline for the assessment."),
+    # Operationally fast tracked through the check if you can get legal aid means test
+    # E.g. due to risk of harm, are under 18, have trapped capital etc.
+    ("SKIPPED", "SKIPPED", "No details. Client called the helpline directly.")
+    # The client skipped the financial assessment due to clicking "Contact Us" directly.
+)
+
+# Why the user was fast tracked through the check if you can get legal aid means test
+FAST_TRACK_REASON = Choices(
+    # constant, db_id, display string
+    ("HARM", "HARM", "User has indicated they are at risk of harm"),
+    ("MORE_INFO_REQUIRED", "MORE_INFO_REQUIRED", "Further scoping information is required"),
+    ("OTHER", "OTHER", "Other")
+)

--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -535,14 +535,14 @@ EXPRESSIONS_OF_DISSATISFACTION_FLAGS = {
 REASONS_FOR_CONTACTING = Choices(
     # NB: these are duplicated (for translation) in cla_public so change both when necessary!
     # constant, db_id, *english* friendly string
-    ("CANT_ANSWER", "CANT_ANSWER", u"I don’t know how to answer a question"),
-    ("MISSING_PAPERWORK", "MISSING_PAPERWORK", u"I don’t have the paperwork I need"),
-    ("PREFER_SPEAKING", "PREFER_SPEAKING", u"I’d prefer to speak to someone"),
-    ("DIFFICULTY_ONLINE", "DIFFICULTY_ONLINE", u"I have trouble using online services"),
-    ("HOW_SERVICE_HELPS", "HOW_SERVICE_HELPS", u"I don’t understand how this service can help me"),
-    ("AREA_NOT_COVERED", "AREA_NOT_COVERED", u"My problem area isn’t covered"),
-    ("PNS", "PNS", u"I’d prefer not to say"),
-    ("OTHER", "OTHER", u"Another reason"),
+    ("CANT_ANSWER", "CANT_ANSWER", "I don’t know how to answer a question"),
+    ("MISSING_PAPERWORK", "MISSING_PAPERWORK", "I don’t have the paperwork I need"),
+    ("PREFER_SPEAKING", "PREFER_SPEAKING", "I’d prefer to speak to someone"),
+    ("DIFFICULTY_ONLINE", "DIFFICULTY_ONLINE", "I have trouble using online services"),
+    ("HOW_SERVICE_HELPS", "HOW_SERVICE_HELPS", "I don’t understand how this service can help me"),
+    ("AREA_NOT_COVERED", "AREA_NOT_COVERED", "My problem area isn’t covered"),
+    ("PNS", "PNS", "I’d prefer not to say"),
+    ("OTHER", "OTHER", "Another reason"),
 )
 
 OPERATOR_HOURS = {
@@ -574,5 +574,5 @@ FAST_TRACK_REASON = Choices(
     # constant, db_id, display string
     ("HARM", "HARM", "User has indicated they are at risk of harm"),
     ("MORE_INFO_REQUIRED", "MORE_INFO_REQUIRED", "Further scoping information is required"),
-    ("OTHER", "OTHER", "Other")
+    ("OTHER", "OTHER", "Other"),
 )

--- a/cla_common/constants.py
+++ b/cla_common/constants.py
@@ -535,14 +535,14 @@ EXPRESSIONS_OF_DISSATISFACTION_FLAGS = {
 REASONS_FOR_CONTACTING = Choices(
     # NB: these are duplicated (for translation) in cla_public so change both when necessary!
     # constant, db_id, *english* friendly string
-    ("CANT_ANSWER", "CANT_ANSWER", "I don’t know how to answer a question"),
-    ("MISSING_PAPERWORK", "MISSING_PAPERWORK", "I don’t have the paperwork I need"),
-    ("PREFER_SPEAKING", "PREFER_SPEAKING", "I’d prefer to speak to someone"),
-    ("DIFFICULTY_ONLINE", "DIFFICULTY_ONLINE", "I have trouble using online services"),
-    ("HOW_SERVICE_HELPS", "HOW_SERVICE_HELPS", "I don’t understand how this service can help me"),
-    ("AREA_NOT_COVERED", "AREA_NOT_COVERED", "My problem area isn’t covered"),
-    ("PNS", "PNS", "I’d prefer not to say"),
-    ("OTHER", "OTHER", "Another reason"),
+    ("CANT_ANSWER", "CANT_ANSWER", u"I don’t know how to answer a question"),
+    ("MISSING_PAPERWORK", "MISSING_PAPERWORK", u"I don’t have the paperwork I need"),
+    ("PREFER_SPEAKING", "PREFER_SPEAKING", u"I’d prefer to speak to someone"),
+    ("DIFFICULTY_ONLINE", "DIFFICULTY_ONLINE", u"I have trouble using online services"),
+    ("HOW_SERVICE_HELPS", "HOW_SERVICE_HELPS", u"I don’t understand how this service can help me"),
+    ("AREA_NOT_COVERED", "AREA_NOT_COVERED", u"My problem area isn’t covered"),
+    ("PNS", "PNS", u"I’d prefer not to say"),
+    ("OTHER", "OTHER", u"Another reason"),
 )
 
 OPERATOR_HOURS = {


### PR DESCRIPTION
## What does this pull request do?

- Add financial assessment status constants
- Add fast track reason constants

## Any other changes that would benefit highlighting?

Intentionally left blank.
